### PR TITLE
python3 print requires ()

### DIFF
--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -61,7 +61,7 @@ echo "Running Forseti inventory."
 forseti inventory create --import_as ${MODEL_NAME}
 echo "Finished running Forseti inventory."
 
-GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print json.load(sys.stdin)['status']\""
+GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print(json.load(sys.stdin)['status'])\""
 MODEL_STATUS=`eval $GET_MODEL_STATUS`
 
 if ([ "$MODEL_STATUS" != "SUCCESS" ] && [ "$MODEL_STATUS" != "PARTIAL_SUCCESS" ])

--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -61,7 +61,7 @@ echo "Running Forseti inventory."
 forseti inventory create --import_as ${MODEL_NAME}
 echo "Finished running Forseti inventory."
 
-GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print(json.load(sys.stdin)['status'])\""
+GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python3 -c \"import sys, json; print(json.load(sys.stdin)['status'])\""
 MODEL_STATUS=`eval $GET_MODEL_STATUS`
 
 if ([ "$MODEL_STATUS" != "SUCCESS" ] && [ "$MODEL_STATUS" != "PARTIAL_SUCCESS" ])


### PR DESCRIPTION
python command is old way, and get a syntax error.
python3 print requires `()`.

```
$ MODEL_STATUS=`eval $GET_MODEL_STATUS`
  File "<string>", line 1
    import sys, json; print json.load(sys.stdin)['status']
                               ^
SyntaxError: invalid syntax
```