### PR TITLE
ignore when cscc has the same finding id.

### DIFF
--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -241,9 +241,13 @@ class CsccNotifier(object):
                 new_findings,
                 formatted_cscc_findings)
 
+            cscc_finding_id_list = [f[0] for f in formatted_cscc_findings]
             for finding_list in new_findings:
                 finding_id = finding_list[0]
                 finding = finding_list[1]
+                if finding_id in cscc_finding_id_list:
+                    continue
+
                 LOGGER.debug('Creating finding CSCC:\n%s.', finding)
                 try:
                     client.create_finding(finding, source_id=source_id,


### PR DESCRIPTION
## ワークロード
- forsetiでSCC notifierを有効にしている。これはSecurity Command Center (Security Health Analysis) で検知する内容とforsetiの検知内容を一元管理するため。
- SCC側で検知された内容は、Slackに通知している。（SCC -> Pub/Sub -> Cloud Function -> Slack）

## 問題点
- forsetiはscanするたびに毎回SCCにfinding結果を通知する。つまり、SCC側で毎回新しいfindingが検知されたことになり、scanのたびに同じ違反内容がSlack通知されて邪魔になる。
- 同じ違反の通知は1回のみにしたい。

## 対応
- 既にSCCに存在するfinding_idは送らないようにする。


