### PR TITLE
add flag whether already sent to slack or not

### DIFF
--- a/google/cloud/forseti/common/gcp_type/service_account.py
+++ b/google/cloud/forseti/common/gcp_type/service_account.py
@@ -108,7 +108,8 @@ class ServiceAccount(object):
                          'full_name': item.full_name,
                          'key_algorithm': data.get('keyAlgorithm'),
                          'valid_after_time': data.get('validAfterTime'),
-                         'valid_before_time': data.get('validBeforeTime')})
+                         'valid_before_time': data.get('validBeforeTime'),
+                         'key_type': data.get('keyType')})
         return keys
 
     def __repr__(self):

--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -156,7 +156,8 @@ class CsccNotifier(object):
                     'scanner_index_id': violation.get('scanner_index_id'),
                     'violation_data': (
                         json.dumps(violation.get('violation_data'),
-                                   sort_keys=True))
+                                   sort_keys=True)),
+                    'flag': 'first_notify'
                 },
             }
             findings.append([finding_id, finding])
@@ -246,10 +247,10 @@ class CsccNotifier(object):
                 finding_id = finding_list[0]
                 finding = finding_list[1]
 
-                already_notified = finding_id in cscc_finding_id_list
-                LOGGER.info(f'finding_id: {finding_id}, already_notified: {already_notified}')
-                if already_notified:
-                    continue
+                if finding_id in cscc_finding_id_list:
+                    finding['source_properties']['flag'] = 'cscc_already_notified'
+                else:
+                    LOGGER.info(f'finding_id: {finding_id} is send for the first time')
 
                 LOGGER.debug('Creating finding CSCC:\n%s.', finding)
                 try:

--- a/google/cloud/forseti/scanner/audit/service_account_key_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/service_account_key_rules_engine.py
@@ -325,6 +325,10 @@ class Rule(object):
 
         violations = []
         for key in service_account.keys:
+            key_type = key.get('key_type')
+            if key_type == 'SYSTEM_MANAGED':
+                continue
+
             key_id = key.get('key_id')
             full_name = key.get('full_name')
             LOGGER.debug('Checking key rotation for %s', full_name)


### PR DESCRIPTION
- https://github.com/e-koma/forseti-security/pull/7 で既に検知済みの違反は、SCCに送信しないよう改修したが、しばらくSCCに送信しないままでいると、SCCのViewは過去X日分を表示するため、（見た目上）違反が消えてしまう
- そのため、違反内容はSCCに送り、検知済みflagを追加して、通知側で制御できるようにする
