### PR TITLE
use service account key type to filter system managed service account keys

### DIFF
--- a/google/cloud/forseti/common/gcp_type/service_account.py
+++ b/google/cloud/forseti/common/gcp_type/service_account.py
@@ -108,7 +108,8 @@ class ServiceAccount(object):
                          'full_name': item.full_name,
                          'key_algorithm': data.get('keyAlgorithm'),
                          'valid_after_time': data.get('validAfterTime'),
-                         'valid_before_time': data.get('validBeforeTime')})
+                         'valid_before_time': data.get('validBeforeTime'),
+                         'key_type': data.get('keyType')})
         return keys
 
     def __repr__(self):

--- a/google/cloud/forseti/scanner/audit/service_account_key_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/service_account_key_rules_engine.py
@@ -325,6 +325,10 @@ class Rule(object):
 
         violations = []
         for key in service_account.keys:
+            key_type = key.get('key_type')
+            if key_type == 'SYSTEM_MANAGED':
+                continue
+
             key_id = key.get('key_id')
             full_name = key.get('full_name')
             LOGGER.debug('Checking key rotation for %s', full_name)


### PR DESCRIPTION
Google管理のキーを検出しないように`projects.serviceAccounts.keys`APIのレスポンスの`KeyType`を使ってフィルタリングを行うように処理を変更しました。
https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys